### PR TITLE
refactor(survey): rename survey references to brand surveys for clarity

### DIFF
--- a/src/core/layouts/main-layout/sidebar/sidebarItems.tsx
+++ b/src/core/layouts/main-layout/sidebar/sidebarItems.tsx
@@ -254,7 +254,7 @@ export const rawItems: Readonly<Record<string, SidebarItem>> = {
   },
 
   surveys: {
-    name: "surveys",
+    name: "brand surveys",
     requiredRoles: [ROLE.ADMIN],
 
     href: SURVEY_ROUTES.LIST,

--- a/src/modules/survey/features/market-research-list/index.tsx
+++ b/src/modules/survey/features/market-research-list/index.tsx
@@ -13,13 +13,13 @@ import { SURVEY_ROUTES } from "../../routes/constant";
 
 const statsData = [
   {
-    title: "Total Survey",
+    title: "Total Brand Survey",
     value: 38,
     barColor: "bg-primary",
     icon: true,
   },
   {
-    title: "Active Survey",
+    title: "Active Brand Survey",
     value: 35,
     barColor: "bg-blue-300",
     icon: false,
@@ -238,7 +238,7 @@ const MarketResearchList = () => {
   return (
     <PageContent
       header={{
-        title: "Survey",
+        title: "Brand Surveys",
         description: "View and manage your surveys.",
         actions: (
           <div className="flex gap-2 md:gap-5">
@@ -248,7 +248,7 @@ const MarketResearchList = () => {
               mode="range"
             />
             <Button color={"primary"} asChild>
-              <NavLink to={SURVEY_ROUTES.CREATE}>Add Survey</NavLink>
+              <NavLink to={SURVEY_ROUTES.CREATE}>Add Brand Survey</NavLink>
             </Button>
           </div>
         ),


### PR DESCRIPTION
- Updated the sidebar item name from "surveys" to "brand surveys" for better alignment with terminology.
- Changed titles in the market research list from "Total Survey" and "Active Survey" to "Total Brand Survey" and "Active Brand Survey" respectively.
- Adjusted the page header and button text to reflect the new branding terminology.